### PR TITLE
Set the '_notifiedActivity' flag early

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -469,8 +469,8 @@ void Session::activityStateSet(int state)
         if ( _monitorActivity ) {
             //FIXME:  See comments in Session::monitorTimerDone()
             if (!_notifiedActivity) {
-                emit activity();
                 _notifiedActivity=true;
+                emit activity();
             }
         }
     }


### PR DESCRIPTION
This way anyone listening to 'activity' signals can safely re-set the flag to
'false' by calling setMonitorActivity(true) again. Right now this is not
guaranteed as the signal is handled asynchonously (and indeed in my PyQT-based
application the signal would be handled *before* the flag is set to 'true'...)