### PR TITLE
Fix: typo in TerminalDisplay

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2916,7 +2916,7 @@ void TerminalDisplay::dragEnterEvent(QDragEnterEvent* event)
 {
   if (event->mimeData()->hasFormat("text/plain"))
       event->acceptProposedAction();
-  if (event->mimeData()->urls().count());
+  if (event->mimeData()->urls().count())
       event->acceptProposedAction();
 }
 


### PR DESCRIPTION
I found this issue when I was building cool-retro-term. GCC detects
a suspicious 'empty body', and I decided to fix it.